### PR TITLE
Add support for ini files

### DIFF
--- a/bin/check-mysql-disk.rb
+++ b/bin/check-mysql-disk.rb
@@ -12,6 +12,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'mysql'
+require 'inifile'
 
 class CheckMysqlDisk < Sensu::Plugin::Check::CLI
   option :host,
@@ -28,6 +29,11 @@ class CheckMysqlDisk < Sensu::Plugin::Check::CLI
          short: '-p',
          long: '--password=VALUE',
          description: 'Database password'
+
+  option :ini,
+         description: 'My.cnf ini file',
+         short: '-i',
+         long: '--ini VALUE'
 
   option :size,
          short: '-s',
@@ -56,9 +62,16 @@ class CheckMysqlDisk < Sensu::Plugin::Check::CLI
          exit: 0
 
   def run
+    if config[:ini]
+      ini = IniFile.load(config[:ini])
+      section = ini['client']
+      db_user = section['user']
+      db_pass = section['password']
+    else
+      db_user = config[:user]
+      db_pass = config[:pass]
+    end
     db_host = config[:host]
-    db_user = config[:user]
-    db_pass = config[:pass]
     disk_size = config[:size].to_f
     critical_usage = config[:crit].to_f
     warning_usage = config[:warn].to_f


### PR DESCRIPTION
Support for using the ini files to login was added to a few of the checks, but not all of them for some reason. I went ahead and added that support to the other files. I tried these out on my system and they all work when using an ini or user/pass to login.

I'm not sure if there was a reason this support was only added to a few of the checks. I'm assuming something similar to me. Someone needed it in one or two checks and left it at that.

Let me know if you see anything that needs changing.