### PR TITLE
Added socket section to ini file - alive + graphite

### DIFF
--- a/bin/check-mysql-alive.rb
+++ b/bin/check-mysql-alive.rb
@@ -74,13 +74,15 @@ class CheckMySQL < Sensu::Plugin::Check::CLI
       section = ini['client']
       db_user = section['user']
       db_pass = section['password']
+      db_section = section['socket']
     else
       db_user = config[:user]
       db_pass = config[:password]
+      db_socket = config[:socket]
     end
 
     begin
-      db = Mysql.real_connect(config[:hostname], db_user, db_pass, config[:database], config[:port].to_i, config[:socket])
+      db = Mysql.real_connect(config[:hostname], db_user, db_pass, config[:database], config[:port].to_i, db_socket)
       info = db.get_server_info
       ok "Server version: #{info}"
     rescue Mysql::Error => e

--- a/bin/metrics-mysql-graphite.rb
+++ b/bin/metrics-mysql-graphite.rb
@@ -199,9 +199,11 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
         section = ini['client']
         db_user = section['user']
         db_pass = section['password']
+        db_socket = section['socket']
       else
         db_user = config[:username]
         db_pass = config[:password]
+        db_socket = config[:socket]
       end
       begin
         mysql = Mysql2::Client.new(
@@ -209,7 +211,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
           port: config[:port],
           username: db_user,
           password: db_pass,
-          socket: config[:socket]
+          socket: db_socket
         )
 
         results = mysql.query('SHOW GLOBAL STATUS')


### PR DESCRIPTION
we populate the /etc/sensu/my.cnf with MySQL user and pass. But usually we need to point the path of used MySQL socket which is not always /var/lib/mysql/mysql.sock
- Thus, enabling socket param in /etc/sensu/my.cnf is the best option (Since using --socket option from sensu server is impossible when differents clients have different mysql paths):
  Just this would do:

``` ruby

def run
    if config[:ini]
      ini = IniFile.load(config[:ini])
      section = ini['client']
      db_user = section['user']
      db_pass = section['password']
      db_socket = section['socket']
    else
      db_user = config[:user]
      db_pass = config[:password]
      db_socket = config[:socket]
    end

    begin
      db = Mysql.real_connect(config[:hostname], db_user, db_pass, config[:database], config[:port].to_i, db_socket)

```
