### PR TITLE
Add max_connections in metrics-mysql-graphite.rb

### DIFF
--- a/bin/metrics-mysql-graphite.rb
+++ b/bin/metrics-mysql-graphite.rb
@@ -188,6 +188,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
         'Innodb_rows_inserted' =>             'rowsInserted'
       },
       'configuration' => {
+        'max_connections'         =>          'MaxConnections',
         'Max_prepared_stmt_count' =>          'MaxPreparedStmtCount'
       }
     }


### PR DESCRIPTION
The metric max_connections is an import number to monitor and show on graphite. http://blog.webyog.com/2012/09/03/top-10-things-to-monitor-on-your-mysql/