### PR TITLE
Replace deprecated mysql with mysql2 in check-mysql-connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - added check-mysql-threads.rb script
 
+### Changed
+- replace mysql with mysql2 in check-mysql-connections
+
 ## [0.0.4] - 2015-08-04
 ### Changed
 - updated sensu-plugin gem to 1.2.0


### PR DESCRIPTION
Related to https://github.com/sensu-plugins/sensu-plugins-mysql/issues/12

mysql gem doesn't work natively with ruby 2.0.0+