### PR TITLE
Ruby mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - added check-mysql-threads.rb script
+- changed metrics-mysql-graphite.rb to use mysql / ruby-mysql gem
 
 ## [0.0.4] - 2015-08-04
 ### Changed

--- a/sensu-plugins-mysql.gemspec
+++ b/sensu-plugins-mysql.gemspec
@@ -42,8 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'aws', '2.10.2'
   s.add_runtime_dependency 'inifile', '3.0.0'
-  s.add_runtime_dependency 'mysql', '2.9.1'
-  s.add_runtime_dependency 'mysql2', '0.3.18'
+  s.add_runtime_dependency 'ruby-mysql', '~> 2.9'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

This is in reference to the comments on #18 (though I suppose #12 / #13 are also relevant).

#### General

- [X] RuboCop passes

The code I've touched passes, though there were pre-existing failures.

#### Purpose

While the `mysql` gem is considered deprecated, the `ruby-mysql` gem has had recent updates (okay, not a lot of them) and doesn't require a working C build environment on the Sensu client.

My commits are relative to 2dfa38dbf1 - which is where the `mysql` to `mysql2` conversion starts. If you didn't want to rewrite history, commits after this point could be reverted, or I can include commits to reverse those changes, if that would leave the history looking cleaner.

I understand if the community reckons that `mysql2` is the way to go, though I will probably end up maintaining my fork indefinitely if that's the case.

#### Known Compatiblity Issues

None, I've tested each plugin in a gem environment without `mysql` and `mysql2` installed.