### PR TITLE
Properly close mysql connection in metrics-mysql-graphite.rb

### DIFF
--- a/bin/metrics-mysql-graphite.rb
+++ b/bin/metrics-mysql-graphite.rb
@@ -249,6 +249,8 @@ class MysqlGraphite < Sensu::Plugin::Metric::CLI::Graphite
       rescue => e
         puts e.message
       end
+
+      mysql.close if mysql
     end
 
     ok


### PR DESCRIPTION
Currently the mysql connection is not properly closed in the metrics-mysql-graphite.rb script. This results in metrics-mysql-graphite.rb always reporting a new aborted client connection.