### PR TITLE
Implement Multi Source Replication check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.1.0] - 2016-10-05
+### Added
+- added multi source replication parameter on check-mysql-replication-status.rb
+
 ## [1.0.0] - 2016-08-15
 ### Added
 - added check-mysql-threads.rb script


### PR DESCRIPTION
To check the new Multi Source Replication feature into MySQL 5.7 and MariaDB 10, is added a new parameter called `--master-connection` to specify a master connection name defined in replication setting, this parameter is optional.