### PR TITLE
Adding minimum thresholds to the threads check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+## Added
+- added minimum thresholds to the check-mysql-threads.rb script
 
 ## [1.1.0] - 2016-10-05
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets
This script is not in the examples of the README and the reference to this script in the README don't need to be touched. The header of the file has been updated for documentation.

- [X] Binstubs are created if needed
No need

- [X] RuboCop passes

- [X] Existing tests pass 

#### Purpose

At some point we had issues with some applications misconfigurations ending up having prod app pointing to QA a long time ago and it took us a few hours before noticing. You can imaging the nightmare it can be to get the data back in prod.
Since then we monitor a minimum number of threads on our mysql servers to be sure we have the expected amount of activity on the server.
As we are moving from Nagios to Sensu, we would like to also see this functionality in the Sensu plugin. This is what this PR adds.

Thanks for your help.

#### Known Compatablity Issues
None