### PR TITLE
Get metrics from MySQL's "SHOW PROCESSLIST" query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## Added
 - added minimum thresholds to the check-mysql-threads.rb script
 - Added metrics plugin with mysql gem requirement
+- Added metrics plugin from `SHOW PROCESSLIST`
 
 ## [1.1.1] - 2016-10-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
  * bin/check-mysql-innodb-lock.rb
  * bin/check-mysql-threads.rb
  * bin/metrics-mysql-graphite.rb
+ * bin/metrics-mysql-processes.rb
  * bin/metrics-mysql-raw.rb
  * bin/metrics-mysql.rb
  * bin/mysql-metrics.sql

--- a/bin/metrics-mysql-processes.rb
+++ b/bin/metrics-mysql-processes.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env ruby
+#
+# metrics-mysql-processes
+#
+# DESCRIPTION:
+#   Gets metrics out of of MySQL's "SHOW PROCESSLIST" query.
+#
+#   Output number of connections per-users, number of connections
+#   per-databases, number of the different commands running.
+#
+# OUTPUT:
+#   metric-data
+#
+# PLATFORMS:
+#   Linux, Windows, BSD, Solaris, etc
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: mysql
+#
+# USAGE:
+#   This was implemented to load mysql credentials without parsing the username/password.
+#   The ini file should be readable by the sensu user/group.
+#   Ref: http://eric.lubow.org/2009/ruby/parsing-ini-files-with-ruby/
+#
+#   EXAMPLE
+#     mysql-alive.rb -h db01 --ini '/etc/sensu/my.cnf'
+#
+#   MY.CNF INI FORMAT
+#   [client]
+#   user=sensu
+#   password="abcd1234"
+#
+# NOTES:
+#
+# LICENSE:
+#   Jonathan Ballet <jballet@edgelab.ch>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'sensu-plugin/metric/cli'
+require 'mysql'
+require 'socket'
+require 'inifile'
+
+class MetricsMySQLProcesses < Sensu::Plugin::Metric::CLI::Graphite
+  option :host,
+         short: '-h HOST',
+         long: '--host HOST',
+         description: 'MySQL Host to connect to',
+         required: true
+
+  option :port,
+         short: '-P PORT',
+         long: '--port PORT',
+         description: 'MySQL Port to connect to',
+         proc: proc(&:to_i),
+         default: 3306
+
+  option :username,
+         short: '-u USERNAME',
+         long: '--user USERNAME',
+         description: 'MySQL Username'
+
+  option :password,
+         short: '-p PASSWORD',
+         long: '--pass PASSWORD',
+         description: 'MySQL password',
+         default: ''
+
+  option :ini,
+         short: '-i',
+         long: '--ini VALUE',
+         description: 'My.cnf ini file'
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.mysql"
+
+  option :socket,
+         short: '-S SOCKET',
+         long: '--socket SOCKET',
+         description: 'MySQL Unix socket to connect to'
+
+  def run
+    config[:host].split(' ').each do |mysql_host|
+      mysql_shorthostname = mysql_host.split('.')[0]
+      if config[:ini]
+        ini = IniFile.load(config[:ini])
+        section = ini['client']
+        db_user = section['user']
+        db_pass = section['password']
+      else
+        db_user = config[:username]
+        db_pass = config[:password]
+      end
+      begin
+        mysql = Mysql.new(mysql_host, db_user, db_pass, nil, config[:port], config[:socket])
+
+        results = mysql.query('SHOW PROCESSLIST')
+      rescue => e
+        unknown "Unable to query MySQL: #{e.message}"
+      end
+
+      metrics = {
+        'user' => {},
+        'database' => {},
+        'command' => {}
+      }
+
+      metrics.each_value { |value| value.default = 0 }
+
+      results.each_hash do |row|
+        metrics['user'][row['User']] += 1
+        if row['db'] # If no database has been selected by the process, it is set to nil.
+          metrics['database'][row['db']] += 1
+        end
+        metrics['command'][row['Command']] += 1
+      end
+
+      metrics.each do |key, value|
+        value.each do |instance, count|
+          output "#{config[:scheme]}.#{mysql_shorthostname}.#{key}.#{instance}", count
+        end
+      end
+    end
+
+    ok
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Collect metrics from MySQL's ``SHOW PROCESSLIST`` query, such as count of connected users, per-databases, and count of types of queries running.

#### Known Compatablity Issues

None