### PR TITLE
update check-mysql-replication-status, check-mysql-alive to use mysql2 gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Add testing on Ruby 2.4 (@eheydrick)
 
->>>>>>> master
 ## [1.2.1] - 2017-05-03
 ### Fixed
 - Fix configuration for check-mysql-query-result-count.rb script (@athal7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Switch check-mysql-alive.rb to mysql2 gem
+- Switch check-mysql-replication-status.rb to mysql2 gem 
+
+## [Unreleased]
 ## [1.2.1] - 2017-05-03
 ### Fixed
 - Fix configuration for check-mysql-query-result-count.rb script (@athal7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Switch check-mysql-alive.rb to mysql2 gem
-- Switch check-mysql-replication-status.rb to mysql2 gem 
+- Switch check-mysql-replication-status.rb to mysql2 gem
 
 ## [Unreleased]
 ## [1.2.1] - 2017-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Added
+### Breaking Changes
 - Switch check-mysql-alive.rb to mysql2 gem
 - Switch check-mysql-replication-status.rb to mysql2 gem
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
-The ruby executables are install in path similar to `/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-mysql-0.0.4/bin`
+* The ruby executables are install in path similar to `/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugins-mysql-0.0.4/bin`
+* 'check-mysql-alive' and 'check-mysql-replication-status' use the [mysql2 gem](https://github.com/brianmario/mysql2). This gem requires your preferred MySQL dev package and a compiler. Installation details are [here](https://github.com/brianmario/mysql2#installing).
 
 ## Troubleshooting
 When used in `chef`, if the dependencies are missing, an error may abort the chef-client run:

--- a/bin/check-mysql-alive.rb
+++ b/bin/check-mysql-alive.rb
@@ -27,7 +27,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'mysql'
+require 'mysql2'
 require 'inifile'
 
 class CheckMySQL < Sensu::Plugin::Check::CLI
@@ -80,10 +80,17 @@ class CheckMySQL < Sensu::Plugin::Check::CLI
     end
 
     begin
-      db = Mysql.real_connect(config[:hostname], db_user, db_pass, config[:database], config[:port].to_i, config[:socket])
-      info = db.get_server_info
+      db = Mysql2::Client.new(
+        host: config[:hostname],
+        username: db_user,
+        password: db_pass,
+        database: config[:database],
+        port: config[:port].to_i,
+        socket: config[:socket]
+      )
+      info = db.query('select version()').first.values.first
       ok "Server version: #{info}"
-    rescue Mysql::Error => e
+    rescue Mysql2::Error => e
       critical "Error message: #{e.error}"
     ensure
       db.close if db

--- a/sensu-plugins-mysql.gemspec
+++ b/sensu-plugins-mysql.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'inifile', '3.0.0'
   s.add_runtime_dependency 'ruby-mysql', '~> 2.9'
+  s.add_runtime_dependency 'mysql2', '~> 0.4.6'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-mysql.gemspec
+++ b/sensu-plugins-mysql.gemspec
@@ -34,8 +34,8 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsMySql::Version::VER_STRING
 
   s.add_runtime_dependency 'inifile', '3.0.0'
-  s.add_runtime_dependency 'ruby-mysql', '~> 2.9'
   s.add_runtime_dependency 'mysql2', '~> 0.4.6'
+  s.add_runtime_dependency 'ruby-mysql', '~> 2.9'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

nope

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

The latest Sensu ships with Ruby 2.4. The `mysql` gem is abandoned and will not build on the embedded Ruby. This PR updates check-mysql-replication-status, and check-mysql-alive to use `mysql2 ` instead.

#### Known Compatablity Issues

none