### PR TITLE
fixes #43 by renaming `--check` short option due to conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Change
+- check-mysql-status.rb: renamed short arg of `--check` due to conflicts (@majormoses)
+
+### Changed
+- check-mysql-status.rb: made the options easier to read by splitting them across multiple lines (@majormoses)
+
 ## [1.2.1] - 2017-05-03
 ### Fixed
 - Fix configuration for check-mysql-query-result-count.rb script (@athal7)

--- a/bin/check-mysql-status.rb
+++ b/bin/check-mysql-status.rb
@@ -34,18 +34,75 @@ require 'open3'
 
 # Check MySQL Status
 class CheckMySQLStatus < Sensu::Plugin::Check::CLI
-  option :user, description: 'MySQL User', short: '-u USER', long: '--user USER', default: 'mosim'
-  option :password, description: 'MySQL Password', short: '-p PASS', long: '--password PASS', default: 'mysqlPassWord'
-  option :ini, description: 'My.cnf ini file', short: '-i', long: '--ini VALUE'
-  option :hostname, description: 'Hostname to login to', short: '-h HOST', long: '--hostname HOST', default: 'localhost'
-  option :database, description: 'Database schema to connect to', short: '-d DATABASE', long: '--database DATABASE', default: 'test'
-  option :port, description: 'Port to connect to', short: '-P PORT', long: '--port PORT', default: '3306'
-  option :socket, description: 'Socket to use', short: '-s SOCKET', long: '--socket SOCKET', default: '/var/run/mysqld/mysqld.sock'
-  option :binary, description: 'Absolute path to mysql binary', short: '-b BINARY', long: '--binary BINARY', default: 'mysql'
-  option :check, description: 'type of check: status | replication', short: '-c CHECK', long: '--check CHECK', default: 'status'
-  option :warn, short: '-w', long: '--warning=VALUE', description: 'Warning threshold for replication lag', default: 900
-  option :crit, short: '-c', long: '--critical=VALUE', description: 'Critical threshold for replication lag', default: 1800
-  option :debug, description: 'Print debug info', long: '--debug', default: false
+  option :user,
+         description: 'MySQL User, you really should use ini to hide credentials instead of using me',
+         short: '-u USER',
+         long: '--user USER',
+         default: 'mosim'
+
+  option :password,
+         description: 'MySQL Password, you really should use ini to hide credentials instead of using me',
+         short: '-p PASS',
+         long: '--password PASS',
+         default: 'mysqlPassWord'
+
+  option :ini,
+         description: 'My.cnf ini file',
+         short: '-i',
+         long: '--ini VALUE'
+
+  option :hostname,
+         description: 'Hostname to login to',
+         short: '-h HOST',
+         long: '--hostname HOST',
+         default: 'localhost'
+
+  option :database,
+         description: 'Database schema to connect to',
+         short: '-d DATABASE',
+         long: '--database DATABASE',
+         default: 'test'
+
+  option :port,
+         description: 'Port to connect to',
+         short: '-P PORT',
+         long: '--port PORT',
+         default: '3306'
+
+  option :socket,
+         description: 'Socket to use',
+         short: '-s SOCKET',
+         long: '--socket SOCKET',
+         default: '/var/run/mysqld/mysqld.sock'
+
+  option :binary,
+         description: 'Absolute path to mysql binary',
+         short: '-b BINARY',
+         long: '--binary BINARY',
+         default: 'mysql'
+
+  option :check,
+         description: 'type of check: (status|replication)',
+         short: '-C CHECK',
+         long: '--check CHECK',
+         default: 'status'
+
+  option :warn,
+         description: 'Warning threshold for replication lag',
+         short: '-w',
+         long: '--warning=VALUE',
+         default: 900
+
+  option :crit,
+         description: 'Critical threshold for replication lag',
+         short: '-c',
+         long: '--critical=VALUE',
+         default: 1800
+
+  option :debug,
+         description: 'Print debug info',
+         long: '--debug',
+         default: false
 
   def credentials
     if config[:ini]


### PR DESCRIPTION
Also made it easier to read the args.

## Pull Request Checklist
#43 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
Fix short arg conflict.

#### Known Compatibility Issues
I am calling this a breaking change even though I am not 100% sure its actually a breaking change because I am not sure how it is currently resolving the conflict but it might be more accurate to say it's a patch version...
