### PR TITLE
closes #51 by making `--size || -s` required.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Added minimum viable permissions in `README` for all the checks, metrics, and handlers. (@majormoses)
 
+### Fixed
+- check-mysql-disk.rb: make required options required. (@majormoses)
+
+### Changed
+- check-mysql-disk.rb: misc changes on where option output is cast. (@majormoses)
+
 ## [2.1.0] - 2017-06-10
 ### Added
 - metrics-mysql-query-result-count.rb: Creates a graphite-formatted metric for the length of a result set from a MySQL query. (@athal7)

--- a/bin/check-mysql-disk.rb
+++ b/bin/check-mysql-disk.rb
@@ -38,18 +38,22 @@ class CheckMysqlDisk < Sensu::Plugin::Check::CLI
   option :size,
          short: '-s',
          long: '--size=VALUE',
-         description: 'Database size'
+         description: 'Database size',
+         proc: proc(&:to_f),
+         required: true
 
   option :warn,
          short: '-w',
          long: '--warning=VALUE',
          description: 'Warning threshold',
+         proc: proc(&:to_f),
          default: '85'
 
   option :crit,
          short: '-c',
          long: '--critical=VALUE',
          description: 'Critical threshold',
+         proc: proc(&:to_f),
          default: '95'
 
   option :port,
@@ -76,9 +80,9 @@ class CheckMysqlDisk < Sensu::Plugin::Check::CLI
       db_pass = config[:pass]
     end
     db_host = config[:host]
-    disk_size = config[:size].to_f
-    critical_usage = config[:crit].to_f
-    warning_usage = config[:warn].to_f
+    disk_size = config[:size]
+    critical_usage = config[:crit]
+    warning_usage = config[:warn]
 
     if [db_host, db_user, db_pass, disk_size].any?(&:nil?)
       unknown 'Must specify host, user, password and size'


### PR DESCRIPTION
There is no value in checking if a number is greater than infinite, as there is no sane default I can think of we should make it required to be set.

Other misc changes regarding option casting.

Signed-off-by: Ben Abrams <me@benabrams.it>

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Give the users a better experience by making size a required option.
#### Known Compatibility Issues
None
