### PR TITLE
fixes #48 added support for multiple MySQL flavors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-mysql-replication-status.rb: fix issues with multi-source replication and different MySQL flavors (@radarnex)
+
 ### Changed
 - In `README` clarify why they should not use privileged users for monitoring with sensu. (@majormoses)
 - In `README` add more usage examples. (@rwillmer)


### PR DESCRIPTION
#48 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
Add support for multi-source replication on multiple MySQL flavors. Sorry for my ruby :-(, any comment is welcome.

#### Known Compatablity Issues
None
