### PR TITLE
Improve efficiency when there are a lot of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- Add check-mysql-select-count.rb script (@negachov)
 
 ## [2.3.0] - 2018-03-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ In keeping with the principle of least privilege you should create a new user wi
 | check-mysql-disk.rb                    | `SELECT`                                                  |
 | check-mysql-innodb-lock.rb             | `PROCESS`                                                 |
 | check-mysql-query-result-count.rb      | depends on query                                          |
+| check-mysql-select-count.rb            | `SELECT`                                                  |
 | check-mysql-replication-status.rb      | `SUPER` OR `REPLICATION_CLIENT` (the latter is preferable)|
 | check-mysql-msr-replication-status.rb  | `SELECT`                                                  |
 | check-mysql-status.rb                  | `SELECT`                                                  |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
  * bin/check-mysql-innodb-lock.rb
  * bin/check-mysql-threads.rb
  * bin/check-mysql-query-result-count.rb
+ * bin/check-mysql-select-count.rb
  * bin/check-mysql-msr-replication-status.rb
  * bin/metrics-mysql-graphite.rb
  * bin/metrics-mysql-processes.rb
@@ -85,6 +86,11 @@ $ /opt/sensu/embedded/bin/check-mysql-replication-status.rb --host=<SLAVE> --ini
 **check-mysql-query-result-count** example
 ```bash
 /opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/ruby check-mysql-query-result-count.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --warning 1 --critical 10 --query 'SELECT DISTINCT(t.id) FROM table t where t.failed = true'
+```
+
+**check-mysql-select-count** example
+```bash
+/opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/ruby check-mysql-select-count.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --warning 30000 --critical 50000 --query 'SELECT count(*) FROM table t'
 ```
 
 **metrics-mysql-query-result-count** example

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -106,8 +106,8 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
     errstr = "Error code: #{e.errno} Error message: #{e.error}"
     critical "#{errstr} SQLSTATE: #{e.sqlstate}" if e.respond_to?('sqlstate')
 
-  rescue => e
-    critical e
+  rescue StandardError => e
+    critical "unhandled exception: #{e}"
 
   ensure
     db.close if db

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -91,7 +91,7 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
     end
     raise "invalid query : #{config[:query]}" unless config[:query] =~ /^select\s+count\(\s*\*\s*\)/i
 
-    db = Mysql.real_connect(config[:host], db_user, db_pass, config[:database], config[:port].to_i, config[:socket])
+    db = Mysql.real_connect(config[:host], db_user, db_pass, config[:database], config[:port], config[:socket])
 
     count = db.query(config[:query]).fetch_row[0].to_i
     if count >= config[:crit]

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -37,7 +37,6 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
          short: '-p PASSWORD',
          long: '--pass PASSWORD',
          description: 'MySQL password',
-         default: ''
 
   option :database,
          short: '-d DATABASE',

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+#
+# MySQL Select Count Check
+#
+# Checks the length of a result set from a MySQL query.
+#
+# Copyright 2017 Andrew Thal <athal7@me.com> to check-mysql-query-result-count.rb
+# Modified by Mutsutoshi Yoshimoto <negachov@gmail.com> 2018 to select count(*) version
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'sensu-plugin/check/cli'
+require 'mysql'
+require 'inifile'
+
+class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
+  option :host,
+         short: '-h HOST',
+         long: '--host HOST',
+         description: 'MySQL Host to connect to',
+         required: true
+
+  option :port,
+         short: '-P PORT',
+         long: '--port PORT',
+         description: 'MySQL Port to connect to',
+         proc: proc(&:to_i),
+         default: 3306
+
+  option :username,
+         short: '-u USERNAME',
+         long: '--user USERNAME',
+         description: 'MySQL Username'
+
+  option :password,
+         short: '-p PASSWORD',
+         long: '--pass PASSWORD',
+         description: 'MySQL password',
+         default: ''
+
+  option :database,
+         short: '-d DATABASE',
+         long: '--database DATABASE',
+         description: 'MySQL database',
+         required: true
+
+  option :ini,
+         short: '-i',
+         long: '--ini VALUE',
+         description: 'My.cnf ini file'
+
+  option :ini_section,
+         description: 'Section in my.cnf ini file',
+         long: '--ini-section VALUE',
+         default: 'client'
+
+  option :socket,
+         short: '-S SOCKET',
+         long: '--socket SOCKET',
+         description: 'MySQL Unix socket to connect to'
+
+  option :warn,
+         short: '-w COUNT',
+         long: '--warning COUNT',
+         description: 'COUNT warning threshold for number of items returned by the query',
+         proc: proc(&:to_i),
+         required: true
+
+  option :crit,
+         short: '-c COUNT',
+         long: '--critical COUNT',
+         description: 'COUNT critical threshold for number of items returned by the query',
+         proc: proc(&:to_i),
+         required: true
+
+  option :query,
+         short: '-q SELECT_COUNT_QUERY',
+         long: '--query SELECT_COUNT_QUERY',
+         description: 'Query to execute',
+         required: true
+
+  def run
+    if config[:ini]
+      ini = IniFile.load(config[:ini])
+      section = ini[config[:ini_section]]
+      db_user = section['user']
+      db_pass = section['password']
+    else
+      db_user = config[:username]
+      db_pass = config[:password]
+    end
+    raise "invalid query : #{config[:query]}" unless config[:query].match(/^select\s+count\(\s*\*\s*\)/)
+
+    db = Mysql.real_connect(config[:host], db_user, db_pass, config[:database], config[:port].to_i, config[:socket])
+
+    count = db.query(config[:query]).fetch_row()[0].to_i
+    if count >= config[:crit]
+      critical "Count is above the CRITICAL limit: #{count} count / #{config[:crit]} limit"
+    elsif count >= config[:warn]
+      warning "Count is above the WARNING limit: #{count} count / #{config[:warn]} limit"
+    else
+      ok "Count is below thresholds : #{count} count"
+    end
+
+  rescue Mysql::Error => e
+    errstr = "Error code: #{e.errno} Error message: #{e.error}"
+    critical "#{errstr} SQLSTATE: #{e.sqlstate}" if e.respond_to?('sqlstate')
+
+  rescue => e
+    critical e
+
+  ensure
+    db.close if db
+  end
+end

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -90,7 +90,7 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
       db_user = config[:username]
       db_pass = config[:password]
     end
-    raise "invalid query : #{config[:query]}" unless config[:query].match(/^select\s+count\(\s*\*\s*\)/)
+    raise "invalid query : #{config[:query]}" unless config[:query].match(/^select\s+count\(\s*\*\s*\)/i)
 
     db = Mysql.real_connect(config[:host], db_user, db_pass, config[:database], config[:port].to_i, config[:socket])
 

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -36,7 +36,7 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
   option :password,
          short: '-p PASSWORD',
          long: '--pass PASSWORD',
-         description: 'MySQL password',
+         description: 'MySQL password'
 
   option :database,
          short: '-d DATABASE',

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -62,14 +62,14 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
   option :warn,
          short: '-w COUNT',
          long: '--warning COUNT',
-         description: 'COUNT warning threshold for number of items returned by the query',
+         description: 'Warning when query value exceeds threshold',
          proc: proc(&:to_i),
          required: true
 
   option :crit,
          short: '-c COUNT',
          long: '--critical COUNT',
-         description: 'COUNT critical threshold for number of items returned by the query',
+         description: 'Critical when query value exceeds threshold',
          proc: proc(&:to_i),
          required: true
 

--- a/bin/check-mysql-select-count.rb
+++ b/bin/check-mysql-select-count.rb
@@ -90,11 +90,11 @@ class MysqlSelectCountCheck < Sensu::Plugin::Check::CLI
       db_user = config[:username]
       db_pass = config[:password]
     end
-    raise "invalid query : #{config[:query]}" unless config[:query].match(/^select\s+count\(\s*\*\s*\)/i)
+    raise "invalid query : #{config[:query]}" unless config[:query] =~ /^select\s+count\(\s*\*\s*\)/i
 
     db = Mysql.real_connect(config[:host], db_user, db_pass, config[:database], config[:port].to_i, config[:socket])
 
-    count = db.query(config[:query]).fetch_row()[0].to_i
+    count = db.query(config[:query]).fetch_row[0].to_i
     if count >= config[:crit]
       critical "Count is above the CRITICAL limit: #{count} count / #{config[:crit]} limit"
     elsif count >= config[:warn]


### PR DESCRIPTION
Since check-mysql-query-result-count.rb is inefficient when there are a lot of records, we add the version of select count.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
