### PR TITLE
Mysql select value check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- check-mysql-select-value.rb script (@DrMurx)
 
 ## [2.5.1] - 2018-06-21
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
  * bin/check-mysql-threads.rb
  * bin/check-mysql-query-result-count.rb
  * bin/check-mysql-select-count.rb
+ * bin/check-mysql-select-value.rb
  * bin/check-mysql-msr-replication-status.rb
  * bin/metrics-mysql-graphite.rb
  * bin/metrics-mysql-processes.rb
@@ -93,6 +94,11 @@ $ /opt/sensu/embedded/bin/check-mysql-replication-status.rb --host=<SLAVE> --ini
 /opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/ruby check-mysql-select-count.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --warning 30000 --critical 50000 --query 'SELECT count(*) FROM table t'
 ```
 
+**check-mysql-select-value** example
+```bash
+/opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/ruby check-mysql-select-value.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --warning 1 --critical 2 --query 'SELECT MyStoredFunction()'
+```
+
 **metrics-mysql-query-result-count** example
 ```bash
 /opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/ruby metrics-mysql-query-result-count.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --query 'SELECT DISTINCT(t.id) FROM table t where t.failed = true'
@@ -110,6 +116,7 @@ In keeping with the principle of least privilege you should create a new user wi
 | check-mysql-innodb-lock.rb             | `PROCESS`                                                 |
 | check-mysql-query-result-count.rb      | depends on query                                          |
 | check-mysql-select-count.rb            | `SELECT`                                                  |
+| check-mysql-select-value.rb            | `SELECT`                                                  |
 | check-mysql-replication-status.rb      | `SUPER` OR `REPLICATION_CLIENT` (the latter is preferable)|
 | check-mysql-msr-replication-status.rb  | `SELECT`                                                  |
 | check-mysql-status.rb                  | `SELECT`                                                  |


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [ ] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

This is basically a generalization of `check-mysql-select-count.rb` which doesn't limit the user to a `SELECT Count(*)` statement - instead, any value from the first column of the first result set is used. This allows to select arbitrary values, functions or variables.

Additionally, depending on the value of `warning` and `critical`, the check checks for a upper or a lower threshold.