### PR TITLE
Script metrics-mysql-multiple-select-count added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- metrics-mysql-multiple-select-countcript (@nagyt234)
 
 
 ## [3.0.0] - 2018-12-04

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
  * bin/check-mysql-select-count.rb
  * bin/check-mysql-msr-replication-status.rb
  * bin/metrics-mysql-graphite.rb
+ * bin/metrics-mysql-multiple-select-count.rb
  * bin/metrics-mysql-processes.rb
  * bin/metrics-mysql-raw.rb
  * bin/metrics-mysql.rb
@@ -104,6 +105,10 @@ $ /opt/sensu/embedded/bin/check-mysql-replication-status.rb --host=<SLAVE> --ini
 /opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/ruby metrics-mysql-select-count.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --query 'SELECT COUNT(*) FROM table t'
 ```
 
+**metrics-mysql-multiple-select-count** example
+```bash
+/opt/sensu/embedded/bin$ /opt/sensu/embedded/bin/metrics-mysql-multiple-select-count.rb --host=localhost --port=3306 --user=collectd --pass=tflypass --socket=/data/mysql.sock --query '{"t1_count":"SELECT COUNT(*) FROM table t1", "t2_count":"SELECT COUNT(*) FROM table t2"}'
+```
 ### Security
 
 In keeping with the principle of least privilege you should create a new user with the minimum required permissions. See the table below for minimum permissions for each check.
@@ -124,6 +129,7 @@ In keeping with the principle of least privilege you should create a new user wi
 | metrics-mysql-processes.rb             | `SELECT`                                                  |
 | metrics-mysql-query-result-count.rb    | depends on query                                          |
 | metrics-mysql-select-count.rb          | depends on query                                          |
+| metrics-mysql-multiple-select-count    | depends on query                                          |
 | metrics-mysql-raw.rb                   | `SELECT`                                                  |
 | metrics-mysql.rb                       | `INSERT` into `sensumetrics.sensu_historic_metrics`       |
 

--- a/bin/metrics-mysql-multiple-select-count.rb
+++ b/bin/metrics-mysql-multiple-select-count.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+#
+# MySQL Select Count Metrics
+#
+# Creates a graphite-formatted metrics for the first values of a result set from MySQL queries
+# defined as a JSON parameter.
+#
+# Copyright 2017 Andrew Thal <athal7@me.com>
+# Copyright 2018 Tibor Nagy <nagyt@hu.inter.net>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'sensu-plugin/metric/cli'
+require 'mysql'
+require 'inifile'
+require 'json'
+
+class MysqlQueryCountMetric < Sensu::Plugin::Metric::CLI::Graphite
+  option :host,
+         short: '-h HOST',
+         long: '--host HOST',
+         description: 'MySQL Host to connect to',
+         required: true
+
+  option :port,
+         short: '-P PORT',
+         long: '--port PORT',
+         description: 'MySQL Port to connect to',
+         proc: proc(&:to_i),
+         default: 3306
+
+  option :username,
+         short: '-u USERNAME',
+         long: '--user USERNAME',
+         description: 'MySQL Username'
+
+  option :password,
+         short: '-p PASSWORD',
+         long: '--pass PASSWORD',
+         description: 'MySQL password'
+
+  option :database,
+         short: '-d DATABASE',
+         long: '--database DATABASE',
+         description: 'MySQL database',
+         default: ''
+
+  option :ini,
+         short: '-i',
+         long: '--ini VALUE',
+         description: 'My.cnf ini file'
+
+  option :ini_section,
+         description: 'Section in my.cnf ini file',
+         long: '--ini-section VALUE',
+         default: 'client'
+
+  option :socket,
+         short: '-S SOCKET',
+         long: '--socket SOCKET',
+         description: 'MySQL Unix socket to connect to'
+
+  option :name,
+         short: '-n NAME',
+         long: '--name NAME',
+         description: 'Metric name for a configured handler',
+         default: 'mysql.query_count'
+
+  option :query,
+         short: '-q SELECT_COUNT_QUERIES',
+         long: '--query SELECT_COUNT_QUERIES',
+         description: 'Queries to execute in JSON',
+         required: true
+
+  def run
+    if config[:ini]
+      ini = IniFile.load(config[:ini])
+      section = ini[config[:ini_section]]
+      db_user = section['user']
+      db_pass = section['password']
+    else
+      db_user = config[:username]
+      db_pass = config[:password]
+    end
+
+    begin
+      query_hash = ::JSON.parse config[:query]
+    rescue ::JSON::ParserError => e
+      critical "JSON.parse error: #{e}"
+    end
+
+    # traverse all SQL
+    query_hash.each do |key, sql|
+      raise "invalid query : #{sql}" unless sql =~ /^select\s+count\(\s*\*\s*\)/i
+
+      db = Mysql.real_connect(config[:host], db_user, db_pass, config[:database], config[:port], config[:socket])
+      count = db.query(sql).fetch_row[0].to_i
+
+      output "#{config[:name]}.#{key}", count
+    end
+
+    ok
+  rescue Mysql::Error => e
+    errstr = "Error code: #{e.errno} Error message: #{e.error}"
+    critical "#{errstr} SQLSTATE: #{e.sqlstate}" if e.respond_to?('sqlstate')
+  rescue StandardError => e
+    critical "unhandled exception: #{e}"
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

The script metrics-mysql-select-count is not efficient enough, if multiple count metrics requested, because the majority of the CPU load is the starting of the script. The new  metrics-mysql-multiple-select-count is implemented to solve this problem. Unlimited number of SQL count queries can be defined as a JSON string.

#### Known Compatibility Issues

#### Manual test
```
$ mysql -uroot -p**** test -e 'SELECT COUNT(*) FROM foo;SELECT COUNT(*) FROM bar;'
mysql: [Warning] Using a password on the command line interface can be insecure.
+----------+
| COUNT(*) |
+----------+
|   114059 |
+----------+
+----------+
| COUNT(*) |
+----------+
|    90941 |
+----------+
$ bin/metrics-mysql-multiple-select-count.rb -d test -h localhost -S /var/run/mysqld/mysqld.sock -u root -p**** -q '{"foo_count":"SELECT COUNT(*) FROM foo", "bar_count":"SELECT COUNT(*) FROM bar"}'
mysql.query_count.foo_count 114059 1544534615
mysql.query_count.bar_count 90941 1544534615
```